### PR TITLE
Simplify getting started

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -192,7 +192,7 @@
             <div class="line comment"># install reana-cluster utility</div>
             <div class="line"><span class="prompt">$</span>pip install reana-cluster</div>
             <div class="line comment"># deploy new cluster and check progress</div>
-            <div class="line"><span class="prompt">$</span>reana-cluster init --traefik --generate-db-secrets</div>
+            <div class="line"><span class="prompt">$</span>reana-cluster init</div>
             <div class="line"><span class="prompt">$</span>reana-cluster status</div>
             <div class="line comment"># set environment variables for client</div>
             <div class="line"><span class="prompt">$</span>eval $(reana-cluster env --include-admin-token)</div>


### PR DESCRIPTION
* As a side effect of refactoring the `reana-cluster init` to
  autogenerate deployment REANA secrets see
  reanahub/reana-cluster#242 the mandatory `--traefik` has been
  removed in favour of `--create-traefik` which is set to
  default and `--skip-create-traefik`. The reason is to simplify
  the operations since this is a hard requirement for the
  Interactive Sessions feature.