### PR TITLE
docker: podman-friendly image locations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.18
+FROM docker.io/library/nginx:1.18
 EXPOSE 8080
 # hadolint ignore=DL3008, DL3015
 RUN apt-get -y update && \

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,13 @@ Installation
 
 .. code-block:: console
 
-   $ docker build -t reanahub/wwwreanaio .
+   $ docker build -t docker.io/reanahub/wwwreanaio .
 
 Running
 -------
 
 .. code-block:: console
 
-   $ docker run --name wwwreanaio -d -p 8080:8080 reanahub/wwwreanaio
+   $ docker run --name wwwreanaio -d -p 8080:8080 docker.io/reanahub/wwwreanaio
    $ firefox http://localhost:8080/
    $ docker stop wwwreanaio && docker rm wwwreanaio

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # This file is part of REANA.
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020, 2023 CERN.
 #
 # REANA is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,11 +24,11 @@ check_docstyle () {
 }
 
 check_dockerfile () {
-    docker run -i --rm hadolint/hadolint:v1.18.2 < Dockerfile
+    docker run -i --rm docker.io/hadolint/hadolint:v1.18.2 < Dockerfile
 }
 
 check_docker_build () {
-    docker build -t reanahub/wwwreanaio .
+    docker build -t docker.io/reanahub/wwwreanaio .
 }
 
 check_all () {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -20,7 +20,7 @@ check_script () {
 }
 
 check_docstyle () {
-    awesome_bot --allow-dupe --skip-save-results --allow-redirect --white-list https://reana.cern.ch -- templates/**/*.html
+    awesome_bot --allow-dupe --skip-save-results --allow-redirect --white-list https://reana.cern.ch,https://twitter.com/reanahub/lists/reana-developers,https://gitter.im/reanahub/reana -- templates/**/*.html
 }
 
 check_dockerfile () {


### PR DESCRIPTION
Adds fully qualified canonical locations of container images, making the container technology setup podman-friendly.

Closes reanahub/reana#729.