### PR TITLE
ci(commitlint): check for the presence of concrete PR number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check commit message compliance of the pull request
         if: github.event_name == 'pull_request'
         run: |
-          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} ${{ github.event.pull_request.head.sha }}
+          ./run-tests.sh --check-commitlint ${{ github.event.pull_request.head.sha }}~${{ github.event.pull_request.commits }} ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.number }}
 
   lint-shellcheck:
     runs-on: ubuntu-20.04

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -31,7 +31,7 @@ check_commitlint () {
 }
 
 check_shellcheck () {
-    find . -name "*.sh" -exec shellcheck {} \;
+    find . -name "*.sh" -exec shellcheck {} \+
 }
 
 check_docstyle () {

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,13 +15,14 @@ shopt -s globstar
 check_commitlint () {
     from=${2:-master}
     to=${3:-HEAD}
+    pr=${4:-[0-9]+}
     npx commitlint --from="$from" --to="$to"
     found=0
     while IFS= read -r line; do
-        if echo "$line" | grep -qP "\(\#[0-9]+\)$"; then
+        if echo "$line" | grep -qP "\(\#$pr\)$"; then
             true
         else
-            echo "✖   PR number missing in $line"
+            echo "✖   Headline does not end by '(#$pr)' PR number: $line"
             found=1
         fi
     done < <(git log "$from..$to" --format="%s")


### PR DESCRIPTION
- ci(commitlint): check for the presence of concrete PR number

    Enrich commitlint checker in order to check the precise PR number in the
    commit log headline.

- ci(shellcheck): fix exit code propagation

    Return properly the exit code status of shellcheck command when looping
    through shell script files.