### PR TITLE
feat(page): add first 2025 presentations

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -364,19 +364,31 @@
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>November 24th-29th 2024:</strong> REANA runs a reproducible workflow training at the <em>EURO-LABS Advanced Training: Open Science and Data Management</em> in Ebernburg, Germany. <a href="https://indico.gsi.de/event/19808/">[event]</a> <a href="https://indico.gsi.de/event/19808/contributions/84384/attachments/49687/72573/reana-eurolabs-20241124.pdf">[slides]</a>
+                  <strong>February 17-18th 2025:</strong> Tibor presents <em>REANA: status and plans</em> at the CMS Physics Days event focused on Beyond the Standard Model Combinations. <a href="https://simko.web.cern.ch/talks/reana-cms-physics-days-20250218.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>November 4th-8th 2024:</strong> REANA runs a reproducible workflow training at the <em>1st CERN School of Computing on IT Services</em> in Ferney-Voltaire, France. <a href="https://indico.cern.ch/event/1441237/">[event]</a> <a href="https://indico.cern.ch/event/1441237/contributions/6073466/attachments/2962323/5211163/reana-tcsc-20240804.pdf">[slides]</a> <a href="https://indico.cern.ch/event/1441237/contributions/6073467/attachments/2962247/5210471/reana-tcsc-20240804-exercises.pdf">[exercises]</a>
+                  <strong>February 14th 2025:</strong> Alp presents <em>Supporting Dask workloads in the REANA reproducible analysis platform</em> at the IRIS-HEP Analysis Grand Challenge Demo Day 7. <a href="https://indico.cern.ch/event/1487508/">[event]</a> <a href="https://indico.cern.ch/event/1487508/contributions/6342602/attachments/3015475/5318085/REANA%20with%20Dask.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>October 19th-25th 2024:</strong> REANA participates at the <em>Conference on Computing in High Energy and Nuclear Physics (CHEP 2024)</em> in Krakow, Poland. <a href="https://indico.cern.ch/event/1338689/">[event]</a> <a href="https://indico.cern.ch/event/1338689/contributions/6010709/attachments/2953224/5191926/chep2024-reana-agc.pdf">[slides]</a>
+                  <strong>November 24th-29th 2024:</strong> Tibor runs a reproducible workflow training at the <em>EURO-LABS Advanced Training: Open Science and Data Management</em> in Ebernburg, Germany. <a href="https://indico.gsi.de/event/19808/">[event]</a> <a href="https://indico.gsi.de/event/19808/contributions/84384/attachments/49687/72573/reana-eurolabs-20241124.pdf">[slides]</a>
+                </td>
+              </tr>
+              <tr>
+                <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
+                <td>
+                  <strong>November 4th-8th 2024:</strong> Marco and Tibor run a reproducible workflow training at the <em>1st CERN School of Computing on IT Services</em> in Ferney-Voltaire, France. <a href="https://indico.cern.ch/event/1441237/">[event]</a> <a href="https://indico.cern.ch/event/1441237/contributions/6073466/attachments/2962323/5211163/reana-tcsc-20240804.pdf">[slides]</a> <a href="https://indico.cern.ch/event/1441237/contributions/6073467/attachments/2962247/5210471/reana-tcsc-20240804-exercises.pdf">[exercises]</a>
+                </td>
+              </tr>
+              <tr>
+                <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
+                <td>
+                  <strong>October 19th-25th 2024:</strong> Marco participates at the <em>Conference on Computing in High Energy and Nuclear Physics (CHEP 2024)</em> in Krakow, Poland. <a href="https://indico.cern.ch/event/1338689/">[event]</a> <a href="https://indico.cern.ch/event/1338689/contributions/6010709/attachments/2953224/5191926/chep2024-reana-agc.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
@@ -388,13 +400,13 @@
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>October 2nd-3rd 2024:</strong> REANA participates at the <em>4th DPHEP Collaboration Workshop</em> in Geneva, Switzerland. <a href="https://indico.cern.ch/event/1432766/">[event]</a> <a href="https://indico.cern.ch/event/1432766/contributions/6102894/attachments/2939601/5164277/REANA-4th-DPHEP-Workshop-20241002.pdf">[slides]</a>
+                  <strong>October 2nd-3rd 2024:</strong> Marco and Tibor participate at the <em>4th DPHEP Collaboration Workshop</em> in Geneva, Switzerland. <a href="https://indico.cern.ch/event/1432766/">[event]</a> <a href="https://indico.cern.ch/event/1432766/contributions/6102894/attachments/2939601/5164277/REANA-4th-DPHEP-Workshop-20241002.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>September 17th-18th 2024:</strong> REANA participates at the <em>2nd Next Generation Environment for Interoperable Data Analysis Expert Workshop</em> in Dortmund, Germany. <a href="https://indico.desy.de/event/45148/">[event]</a> <a href="https://indico.desy.de/event/45148/contributions/174550/attachments/92484/125211/reana-erum-20240917.pdf">[slides]</a>
+                  <strong>September 17th-18th 2024:</strong> Tibor participates at the <em>2nd Next Generation Environment for Interoperable Data Analysis Expert Workshop</em> in Dortmund, Germany. <a href="https://indico.desy.de/event/45148/">[event]</a> <a href="https://indico.desy.de/event/45148/contributions/174550/attachments/92484/125211/reana-erum-20240917.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
@@ -406,37 +418,31 @@
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>June 20th 2024:</strong> Presentation of REANA at the <em>Swiss Reproducibility Network</em> comuptational reproducibility seminar. <a href="https://www.swissrn.org/contents/activities/computational%20reproducibility/#seminar">[series]</a>  <a href="https://simko.web.cern.ch/tmp/reana-swissrn-webinar-20240620.pdf">[slides]</a>
+                  <strong>June 20th 2024:</strong> Tibor presents REANA at the <em>Swiss Reproducibility Network</em> comuptational reproducibility seminar. <a href="https://www.swissrn.org/contents/activities/computational%20reproducibility/#seminar">[series]</a>  <a href="https://simko.web.cern.ch/talks/reana-swissrn-webinar-20240620.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>June 18th-20th 2024:</strong> REANA participates at the <em>Analysis Facilities Workshop</em> in Garching, Germany. <a href="https://indico.desy.de/event/44722/">[event]</a>  <a href="https://indico.desy.de/event/44722/contributions/168275/attachments/90958/122752/reana-analysis-facilities-workshop-20240619.pdf">[slides]</a>
+                  <strong>June 18th-20th 2024:</strong> Tibor participates at the <em>Analysis Facilities Workshop</em> in Garching, Germany. <a href="https://indico.desy.de/event/44722/">[event]</a>  <a href="https://indico.desy.de/event/44722/contributions/168275/attachments/90958/122752/reana-analysis-facilities-workshop-20240619.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>April 3rd-5th 2024:</strong> REANA participates at the <em>Workshop on workflow languages for HEP analysis</em> in Geneva, Switzerland. <a href="https://indico.cern.ch/event/1380367/">[event]</a> <a href="https://indico.cern.ch/event/1380367/contributions/5880496/attachments/2831888/4947909/reana-workflow-language-workshop-20240405.pdf">[slides]</a>
+                  <strong>April 3rd-5th 2024:</strong> Andrii, Marco and Tibor participate at the <em>Workshop on workflow languages for HEP analysis</em> in Geneva, Switzerland. <a href="https://indico.cern.ch/event/1380367/">[event]</a> <a href="https://indico.cern.ch/event/1380367/contributions/5880496/attachments/2831888/4947909/reana-workflow-language-workshop-20240405.pdf">[slides]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fas fa-book event-conference"></i></td>
                 <td>
-                  <strong>April 2nd 2024:</strong> REANA in the <em>Analysis Facilities White Paper</em>. <a href="https://arxiv.org/abs/2404.02100">[paper]</a>
+                  <strong>April 2nd 2024:</strong> REANA featured in the <em>Analysis Facilities White Paper</em>. <a href="https://arxiv.org/abs/2404.02100">[paper]</a>
                 </td>
               </tr>
               <tr>
                 <td class="events-list-header"><i class="fab fa-slideshare event-conference"></i></td>
                 <td>
-                  <strong>February 26th-March 1st 2024:</strong> REANA presents at the <em>HSF Training on Analysis Pipelines</em>. <a href="https://indico.cern.ch/event/1375507/">[event]</a> <a href="https://indico.cern.ch/event/1375507/contributions/5815001/attachments/2807740/4899665/reana-hsf-analysis-pipelines-20240226.pdf">[slides]</a>     
-                </td>
-              </tr>
-              <tr>
-                <td class="events-list-header"><i class="fas fa-book event-conference"></i></td>
-                <td>
-                  <strong>December 1st 2023:</strong> We have published a new paper <em>Facilitating future open data reuse via continuous integration of actionable data analysis examples</em>. <a href="https://zenodo.org/records/10263204">[paper]</a>
+                  <strong>February 26th-March 1st 2024:</strong> Tibor presents at the <em>HSF Training on Analysis Pipelines</em>. <a href="https://indico.cern.ch/event/1375507/">[event]</a> <a href="https://indico.cern.ch/event/1375507/contributions/5815001/attachments/2807740/4899665/reana-hsf-analysis-pipelines-20240226.pdf">[slides]</a>     
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
Adds first 2025 presentations.

Amends the style of the 2024 presentations to use person names everywhere.

Removes last 2023 event.